### PR TITLE
Correction to hide command - README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Bug Fixes:
    2. Marking a default in the MODULERC is now supported.
    3. User ~/.modulerc has priority over system MODULERC.
    4. System MODULERC  has priority over marking a default in the module tree.
-   5. Installed Modules can be hidden by "hide-module foo/3.2.1" in
+   5. Installed Modules can be hidden by "hide-version foo/3.2.1" in
       any modulerc file.
    6. The system spider cache has changed.  Please update your scripts to
       build spiderT.lua instead of moduleT.lua


### PR DESCRIPTION
There's command like hide-module. The proper way is use hide-version.

```
[easybuild@login4.salomon ~]$ cat .modulerc 
#%Module

hide-module git/2.8.0
```

```bash
[easybuild@login4.salomon ~]$ module load lmod
invalid command name "hide-module"
    while executing
"hide-module git/2.8.0"
    (file "/home/easybuild/.modulerc" line 3)
    invoked from within
"source $mRcFile"
    (procedure "main" line 6)
    invoked from within
"main /home/easybuild/.modulerc"
    ("eval" body line 1)
    invoked from within
"eval main $argv"
    (file "/apps/all/Lmod/7.0.6/lmod/lmod/libexec/RC2lua.tcl" line 89)
Lmod has detected the following error:  Unable to parse: /home/easybuild/.modulerc  Aborting!
```

Correct way:
```bash
[easybuild@login4.salomon ~]$ cat .modulerc 
#%Module

hide-version git/2.8.0
```

```bash
[easybuild@login4.salomon ~]$ module load lmod
[easybuild@login4.salomon ~]$ echo $?
0
```

Well, yes the git/2.8.0 module is not within the ```ml av``.
